### PR TITLE
Add generic post deployment commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ The number of versions to keep on the target VM.  The most recent number of conf
 All others will be removed.  The default behavior is to not remove anything.  This can also be achieved with 
 an explicit value of `"0"`
 
+### `postDeploymentCommands`
+
+A pipe-delimited list of commands to run after the deployment.  These will be run in the directory to which 
+the code was deployed.
+
 ## Example usage
 
 ```
@@ -54,6 +59,7 @@ with:
     version:"v1.0.0"
     key: "~/identityfile"
     artisanCommands: "config:cache|migrate"
+    postDeploymentCommands: "sudo supervisorctl restart foo-worker"
     artifact: "some-other-tarball.tar.gz"
     numberOfVersionsToKeep: 5
 ```

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,10 @@ inputs:
     description: "Number of most recent versions to keep. (0 = all)"
     required: false
     default: "0"
+  postDeploymentCommands:
+    description: "Pipe-delimited list of commands to run as part of the deployment"
+    required: false
+    default: ""
 
 runs:
   using: 'node12'

--- a/dist/index.js
+++ b/dist/index.js
@@ -965,7 +965,8 @@ function getOptions() {
     key: getRequiredInput("key"),
     artisanCommands: core.getInput("artisanCommands").split("|"),
     artifact: core.getInput("artifact"),
-    versionsToKeep: core.getInput("numberOfVersionsToKeep") || 0
+    versionsToKeep: core.getInput("numberOfVersionsToKeep") || 0,
+    postDeploymentCommands: core.getInput("postDeploymentCommands").split("|")
   };
 }
 
@@ -1036,6 +1037,16 @@ async function executeArtisan(options) {
   /* eslint-enable no-restricted-syntax */
 }
 
+async function executePostDeploymentCommands(options) {
+  const { versionsRoot, version } = options;
+  /* eslint-disable no-restricted-syntax */
+  for (const command of options.postDeploymentCommands) {
+    // eslint-disable-next-line no-await-in-loop
+    await executeSSH(options, `cd ${versionsRoot}/${version}; ${command}`);
+  }
+  /* eslint-enable no-restricted-syntax */
+}
+
 async function updateSymlink(options) {
   const { version, versionsRoot } = options;
   await executeSSH(options, `rm -f ${versionsRoot}/current`);
@@ -1083,6 +1094,7 @@ async function main() {
   await updateVersionDirectoryTimeStamp(options);
   await setTargetPermissions(options);
   await executeArtisan(options);
+  await executePostDeploymentCommands(options);
   await updateSymlink(options);
   await removeOldVersions(options);
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -956,6 +956,10 @@ function getRequiredInput(input) {
   return capturedInput;
 }
 
+function parseArrayFromPipeDelimitedString(pipeDelimitedString) {
+  return pipeDelimitedString.split("|").filter(x => x !== "");
+}
+
 function getOptions() {
   return {
     user: getRequiredInput("user"),
@@ -963,10 +967,14 @@ function getOptions() {
     versionsRoot: getRequiredInput("versionsRoot"),
     version: core.getInput("version") || process.env.GITHUB_SHA || "",
     key: getRequiredInput("key"),
-    artisanCommands: core.getInput("artisanCommands").split("|"),
+    artisanCommands: parseArrayFromPipeDelimitedString(
+      core.getInput("artisanCommands")
+    ),
     artifact: core.getInput("artifact"),
     versionsToKeep: core.getInput("numberOfVersionsToKeep") || 0,
-    postDeploymentCommands: core.getInput("postDeploymentCommands").split("|")
+    postDeploymentCommands: parseArrayFromPipeDelimitedString(
+      core.getInput("postDeploymentCommands")
+    )
   };
 }
 

--- a/index.js
+++ b/index.js
@@ -10,6 +10,10 @@ function getRequiredInput(input) {
   return capturedInput;
 }
 
+function parseArrayFromPipeDelimitedString(pipeDelimitedString) {
+  return pipeDelimitedString.split("|").filter(x => x !== "");
+}
+
 function getOptions() {
   return {
     user: getRequiredInput("user"),
@@ -17,10 +21,14 @@ function getOptions() {
     versionsRoot: getRequiredInput("versionsRoot"),
     version: core.getInput("version") || process.env.GITHUB_SHA || "",
     key: getRequiredInput("key"),
-    artisanCommands: core.getInput("artisanCommands").split("|"),
+    artisanCommands: parseArrayFromPipeDelimitedString(
+      core.getInput("artisanCommands")
+    ),
     artifact: core.getInput("artifact"),
     versionsToKeep: core.getInput("numberOfVersionsToKeep") || 0,
-    postDeploymentCommands: core.getInput("postDeploymentCommands").split("|")
+    postDeploymentCommands: parseArrayFromPipeDelimitedString(
+      core.getInput("postDeploymentCommands")
+    )
   };
 }
 

--- a/index.js
+++ b/index.js
@@ -19,7 +19,8 @@ function getOptions() {
     key: getRequiredInput("key"),
     artisanCommands: core.getInput("artisanCommands").split("|"),
     artifact: core.getInput("artifact"),
-    versionsToKeep: core.getInput("numberOfVersionsToKeep") || 0
+    versionsToKeep: core.getInput("numberOfVersionsToKeep") || 0,
+    postDeploymentCommands: core.getInput("postDeploymentCommands").split("|")
   };
 }
 
@@ -90,6 +91,16 @@ async function executeArtisan(options) {
   /* eslint-enable no-restricted-syntax */
 }
 
+async function executePostDeploymentCommands(options) {
+  const { versionsRoot, version } = options;
+  /* eslint-disable no-restricted-syntax */
+  for (const command of options.postDeploymentCommands) {
+    // eslint-disable-next-line no-await-in-loop
+    await executeSSH(options, `cd ${versionsRoot}/${version}; ${command}`);
+  }
+  /* eslint-enable no-restricted-syntax */
+}
+
 async function updateSymlink(options) {
   const { version, versionsRoot } = options;
   await executeSSH(options, `rm -f ${versionsRoot}/current`);
@@ -137,6 +148,7 @@ async function main() {
   await updateVersionDirectoryTimeStamp(options);
   await setTargetPermissions(options);
   await executeArtisan(options);
+  await executePostDeploymentCommands(options);
   await updateSymlink(options);
   await removeOldVersions(options);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "laravel-vm-deployment-action",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "laravel-vm-deployment-action",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
This change serves two purposes:

1. Allow restarting of queue-processing workers on target application servers.  For some reason, I have been unable to get `php artisan queue:restart` to actually result in the task managed by `supervisord` to be restarted.  This change will allow me to use `supervisorctl` to do this manually.
2. Support usage of this action for Kohana apps that have post-deployment tasks where a dependency on `artisan` will never be satisfied.

Resolves #10 