### PR TITLE
Feature/set target permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 node_modules
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ The name of the version to deploy.  Default: sha value of the commit triggering 
 
 A pipe-delimited list of artisan commands to run after the deployment.  Example: `clear-compiled|migrate|optimize`
 
+### `writableDirectories`
+
+A pipe-delimited list of paths relative to the application root that need to be writable by the web server. Example: `storage` for Laravel, `application/cache|application/logs` for Kohana.
+
 ### `artifact`
 
 The path to the deployable tarball.  Default: `./artifact.tar.gz`
@@ -60,6 +64,7 @@ with:
     key: "~/identityfile"
     artisanCommands: "config:cache|migrate"
     postDeploymentCommands: "sudo supervisorctl restart foo-worker"
+    writableDirectories: "storage"
     artifact: "some-other-tarball.tar.gz"
     numberOfVersionsToKeep: 5
 ```

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ The number of versions to keep on the target VM.  The most recent number of conf
 All others will be removed.  The default behavior is to not remove anything.  This can also be achieved with 
 an explicit value of `"0"`
 
+### `postDeploymentCommands`
+
+A pipe-delimited list of commands to run after the deployment.  These will be run in the directory to which 
+the code was deployed.
+
 ## Example usage
 
 ```
@@ -54,6 +59,7 @@ with:
     version:"v1.0.0"
     key: "~/identityfile"
     artisanCommands: "config:cache|migrate"
+    postDeploymentCommands: "sudo supervisorctl restart foo-worker"
     artifact: "some-other-tarball.tar.gz"
     numberOfVersionsToKeep: 5
 ```

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,10 @@ inputs:
     description: "Number of most recent versions to keep. (0 = all)"
     required: false
     default: "0"
+  postDeploymentCommands:
+    description: "Pipe-delimited list of commands to run as part of the deployment"
+    required: false
+    default: ""
 
 runs:
   using: 'node12'

--- a/dist/index.js
+++ b/dist/index.js
@@ -970,6 +970,7 @@ function getOptions() {
     artisanCommands: parseArrayFromPipeDelimitedString(
       core.getInput("artisanCommands")
     ),
+    writableDirectories: core.getInput("writableDirectories").split("|"),
     artifact: core.getInput("artifact"),
     versionsToKeep: core.getInput("numberOfVersionsToKeep") || 0,
     postDeploymentCommands: parseArrayFromPipeDelimitedString(
@@ -1029,7 +1030,16 @@ async function setTargetPermissions(options) {
   const { versionsRoot, version } = options;
   const path = `${versionsRoot}/${version}`;
   await executeSSH(options, `chmod -R 770 ${path}`);
-  await executeSSH(options, `chmod -R 775 ${path}/storage`);
+  /* eslint-disable no-restricted-syntax */
+  for (const dir of options.writableDirectories) {
+    if (dir) {
+      // eslint-disable-next-line no-await-in-loop
+      await executeSSH(
+        options,
+        `stat ${path}/${dir} >/dev/null && chmod -R 775 ${path}/${dir}`
+      );
+    }
+  }
 }
 
 async function executeArtisan(options) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -970,7 +970,9 @@ function getOptions() {
     artisanCommands: parseArrayFromPipeDelimitedString(
       core.getInput("artisanCommands")
     ),
-    writableDirectories: core.getInput("writableDirectories").split("|"),
+    writableDirectories: parseArrayFromPipeDelimitedString(
+      core.getInput("writableDirectories")
+    ),
     artifact: core.getInput("artifact"),
     versionsToKeep: core.getInput("numberOfVersionsToKeep") || 0,
     postDeploymentCommands: parseArrayFromPipeDelimitedString(
@@ -1032,13 +1034,11 @@ async function setTargetPermissions(options) {
   await executeSSH(options, `chmod -R 770 ${path}`);
   /* eslint-disable no-restricted-syntax */
   for (const dir of options.writableDirectories) {
-    if (dir) {
-      // eslint-disable-next-line no-await-in-loop
-      await executeSSH(
-        options,
-        `stat ${path}/${dir} >/dev/null && chmod -R 775 ${path}/${dir}`
-      );
-    }
+    // eslint-disable-next-line no-await-in-loop
+    await executeSSH(
+      options,
+      `stat ${path}/${dir} >/dev/null && chmod -R 775 ${path}/${dir}`
+    );
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -24,7 +24,9 @@ function getOptions() {
     artisanCommands: parseArrayFromPipeDelimitedString(
       core.getInput("artisanCommands")
     ),
-    writableDirectories: core.getInput("writableDirectories").split("|"),
+    writableDirectories: parseArrayFromPipeDelimitedString(
+      core.getInput("writableDirectories")
+    ),
     artifact: core.getInput("artifact"),
     versionsToKeep: core.getInput("numberOfVersionsToKeep") || 0,
     postDeploymentCommands: parseArrayFromPipeDelimitedString(
@@ -86,13 +88,11 @@ async function setTargetPermissions(options) {
   await executeSSH(options, `chmod -R 770 ${path}`);
   /* eslint-disable no-restricted-syntax */
   for (const dir of options.writableDirectories) {
-    if (dir) {
-      // eslint-disable-next-line no-await-in-loop
-      await executeSSH(
-        options,
-        `stat ${path}/${dir} >/dev/null && chmod -R 775 ${path}/${dir}`
-      );
-    }
+    // eslint-disable-next-line no-await-in-loop
+    await executeSSH(
+      options,
+      `stat ${path}/${dir} >/dev/null && chmod -R 775 ${path}/${dir}`
+    );
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -10,6 +10,10 @@ function getRequiredInput(input) {
   return capturedInput;
 }
 
+function parseArrayFromPipeDelimitedString(pipeDelimitedString) {
+  return pipeDelimitedString.split("|").filter(x => x !== "");
+}
+
 function getOptions() {
   return {
     user: getRequiredInput("user"),
@@ -17,9 +21,14 @@ function getOptions() {
     versionsRoot: getRequiredInput("versionsRoot"),
     version: core.getInput("version") || process.env.GITHUB_SHA || "",
     key: getRequiredInput("key"),
-    artisanCommands: core.getInput("artisanCommands").split("|"),
+    artisanCommands: parseArrayFromPipeDelimitedString(
+      core.getInput("artisanCommands")
+    ),
     artifact: core.getInput("artifact"),
-    versionsToKeep: core.getInput("numberOfVersionsToKeep") || 0
+    versionsToKeep: core.getInput("numberOfVersionsToKeep") || 0,
+    postDeploymentCommands: parseArrayFromPipeDelimitedString(
+      core.getInput("postDeploymentCommands")
+    )
   };
 }
 
@@ -90,6 +99,16 @@ async function executeArtisan(options) {
   /* eslint-enable no-restricted-syntax */
 }
 
+async function executePostDeploymentCommands(options) {
+  const { versionsRoot, version } = options;
+  /* eslint-disable no-restricted-syntax */
+  for (const command of options.postDeploymentCommands) {
+    // eslint-disable-next-line no-await-in-loop
+    await executeSSH(options, `cd ${versionsRoot}/${version}; ${command}`);
+  }
+  /* eslint-enable no-restricted-syntax */
+}
+
 async function updateSymlink(options) {
   const { version, versionsRoot } = options;
   await executeSSH(options, `rm -f ${versionsRoot}/current`);
@@ -137,6 +156,7 @@ async function main() {
   await updateVersionDirectoryTimeStamp(options);
   await setTargetPermissions(options);
   await executeArtisan(options);
+  await executePostDeploymentCommands(options);
   await updateSymlink(options);
   await removeOldVersions(options);
 }

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ function getOptions() {
     artisanCommands: parseArrayFromPipeDelimitedString(
       core.getInput("artisanCommands")
     ),
+    writableDirectories: core.getInput("writableDirectories").split("|"),
     artifact: core.getInput("artifact"),
     versionsToKeep: core.getInput("numberOfVersionsToKeep") || 0,
     postDeploymentCommands: parseArrayFromPipeDelimitedString(
@@ -83,7 +84,16 @@ async function setTargetPermissions(options) {
   const { versionsRoot, version } = options;
   const path = `${versionsRoot}/${version}`;
   await executeSSH(options, `chmod -R 770 ${path}`);
-  await executeSSH(options, `chmod -R 775 ${path}/storage`);
+  /* eslint-disable no-restricted-syntax */
+  for (const dir of options.writableDirectories) {
+    if (dir) {
+      // eslint-disable-next-line no-await-in-loop
+      await executeSSH(
+        options,
+        `stat ${path}/${dir} >/dev/null && chmod -R 775 ${path}/${dir}`
+      );
+    }
+  }
 }
 
 async function executeArtisan(options) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "laravel-vm-deployment-action",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "laravel-vm-deployment-action",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
This does introduce a potentially breaking change with Laravel, since it no longer processes the `storage` directory unless it's listed in the appropriate configuration option. Based on the description of #11, maybe that's okay if existing apps are already not using the internal storage directory?

resolves #13, #11 