### PR TITLE
Configurable SSH debug output

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1271,11 +1271,16 @@ async function executeCall(call, options = {}) {
 }
 
 async function executeSSH({ key, user, host }, command, execOptions = {}) {
-  await executeCall(`ssh -i ${key} ${user}@${host} ${command}`, execOptions);
+  const verbose = core.isDebug() ? "-vvv" : "";
+  await executeCall(
+    `ssh ${verbose} -i ${key} ${user}@${host} ${command}`,
+    execOptions
+  );
 }
 
 async function executeSCP({ key }, source, destination) {
-  await executeCall(`scp -i ${key} ${source} ${destination}`);
+  const verbose = core.isDebug() ? "-vvv" : "";
+  await executeCall(`scp ${verbose} -i ${key} ${source} ${destination}`);
 }
 
 async function ensureTargetDirectoryExists(options) {

--- a/index.js
+++ b/index.js
@@ -44,11 +44,16 @@ async function executeCall(call, options = {}) {
 }
 
 async function executeSSH({ key, user, host }, command, execOptions = {}) {
-  await executeCall(`ssh -i ${key} ${user}@${host} ${command}`, execOptions);
+  const verbose = core.isDebug() ? "-vvv" : "";
+  await executeCall(
+    `ssh ${verbose} -i ${key} ${user}@${host} ${command}`,
+    execOptions
+  );
 }
 
 async function executeSCP({ key }, source, destination) {
-  await executeCall(`scp -i ${key} ${source} ${destination}`);
+  const verbose = core.isDebug() ? "-vvv" : "";
+  await executeCall(`scp ${verbose} -i ${key} ${source} ${destination}`);
 }
 
 async function ensureTargetDirectoryExists(options) {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "lint": "eslint index.js",
     "format": "prettier --write .eslintrc package.json index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "ncc build index.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
`core.isDebug()` returns true when a workflow is run with debug logging enabled. That will toggle SSH and SCP debug output in the workflow logs.
